### PR TITLE
Fix CORS

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ require("dotenv").config()
 
 var app = express()
 const corsOptions = {
-  origin: "https://buoyant.io",
+  origin: "https://www.buoyant.io",
   optionsSuccessStatus: 200
 }
 app.use(cors(corsOptions))


### PR DESCRIPTION
site is now www rather than bare domain. This updates the CORS headers to allow vercel to receive client-side requests from www.buoyant.io